### PR TITLE
Add api for HttpClient

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,5 +48,6 @@ object Dependencies {
     val jose4j = "org.bitbucket.b_c" % "jose4j" % "0.5.4"
     val jsonAst = "org.mdedetrich" %% "scala-json-ast" % "1.0.0-M4"
     val bouncyCastle = "org.bouncycastle" % "bcprov-jdk15on" % "1.56"
+    val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.0.6"
   }
 }

--- a/silhouette/src/main/scala/silhouette/exceptions/DecoderException.scala
+++ b/silhouette/src/main/scala/silhouette/exceptions/DecoderException.scala
@@ -15,15 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Dependencies._
+package silhouette.exceptions
 
-libraryDependencies ++= Seq(
-  Library.jsonAst,
-  Library.slf4jApi,
-  Library.inject,
-  Library.commonCodec,
-  Library.Circe.core,
-  Library.Circe.parser,
-  Library.scalaXml
-)
-enablePlugins(Doc)
+/**
+ * Indicates that a decode operation error occurred.
+ *
+ * @param msg   The exception message.
+ * @param cause The exception cause.
+ */
+class DecoderException(msg: String, cause: Option[Throwable] = None)
+  extends SilhouetteException(msg, cause)

--- a/silhouette/src/main/scala/silhouette/exceptions/UnsupportedContentTypeException.scala
+++ b/silhouette/src/main/scala/silhouette/exceptions/UnsupportedContentTypeException.scala
@@ -15,15 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Dependencies._
+package silhouette.exceptions
 
-libraryDependencies ++= Seq(
-  Library.jsonAst,
-  Library.slf4jApi,
-  Library.inject,
-  Library.commonCodec,
-  Library.Circe.core,
-  Library.Circe.parser,
-  Library.scalaXml
-)
-enablePlugins(Doc)
+/**
+ * Indicates that a decode operation could not be done because of Content-type mismatch.
+ *
+ * @param msg   The exception message.
+ * @param cause The exception cause.
+ */
+class UnsupportedContentTypeException(msg: String, cause: Option[Throwable] = None)
+  extends DecoderException(msg, cause)

--- a/silhouette/src/main/scala/silhouette/http/client/Body.scala
+++ b/silhouette/src/main/scala/silhouette/http/client/Body.scala
@@ -15,15 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Dependencies._
+package silhouette.http.client
 
-libraryDependencies ++= Seq(
-  Library.jsonAst,
-  Library.slf4jApi,
-  Library.inject,
-  Library.commonCodec,
-  Library.Circe.core,
-  Library.Circe.parser,
-  Library.scalaXml
+import java.nio.charset.{ Charset, StandardCharsets }
+
+/**
+ * Represents a body of a Request.
+ *
+ * @param contentType The content type of body.
+ * @param data The data of body.
+ */
+final case class Body(
+  contentType: ContentType,
+  charset: Charset = StandardCharsets.UTF_8,
+  data: Array[Byte]
 )
-enablePlugins(Doc)

--- a/silhouette/src/main/scala/silhouette/http/client/ContentTypes.scala
+++ b/silhouette/src/main/scala/silhouette/http/client/ContentTypes.scala
@@ -15,15 +15,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Dependencies._
+package silhouette.http.client
 
-libraryDependencies ++= Seq(
-  Library.jsonAst,
-  Library.slf4jApi,
-  Library.inject,
-  Library.commonCodec,
-  Library.Circe.core,
-  Library.Circe.parser,
-  Library.scalaXml
-)
-enablePlugins(Doc)
+/**
+ * Represents the content type of a request.
+ *
+ * @param value String format for content-type.
+ */
+final case class ContentType(value: String)
+
+/**
+ * Util class for content-type values.
+ */
+object ContentTypes {
+  val `application/json` = ContentType("application/json")
+  val `application/xml` = ContentType("application/xml")
+}

--- a/silhouette/src/main/scala/silhouette/http/client/HttpClient.scala
+++ b/silhouette/src/main/scala/silhouette/http/client/HttpClient.scala
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Minutemen Group under one or more contributor license
+ * agreements. See the COPYRIGHT file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package silhouette.http.client
+
+/**
+ * A client which can be used to process HTTP requests.
+ *
+ * The concrete implementation of this client must be implemented by the framework specific Silhouette binding.
+ * The client is no full-blown HTTP client implementation. It implements only the parts which Silhouette depends on,
+ * and it is only meant for internal usage.
+ *
+ * @tparam B The framework specific [[RequestBuilder]] implementation.
+ */
+private[silhouette] trait HttpClient[B <: RequestBuilder] {
+
+  /**
+   * The framework specific [[RequestBuilder]] implementation.
+   *
+   * @return The framework specific [[RequestBuilder]] implementation.
+   */
+  def requestBuilder: B
+
+  /**
+   * Sets the URL the client should process and returns the framework specific [[RequestBuilder]] implementation
+   * to model the HTTP request.
+   *
+   * @param url The URL to process.
+   * @return The framework specific [[RequestBuilder]] implementation to provide a fluent interface.
+   */
+  def withUrl(url: String): B#Self = requestBuilder.withUrl(url)
+}

--- a/silhouette/src/main/scala/silhouette/http/client/RequestBuilder.scala
+++ b/silhouette/src/main/scala/silhouette/http/client/RequestBuilder.scala
@@ -70,7 +70,7 @@ private[silhouette] trait RequestBuilder {
    * @param body The body to set.
    * @return A request builder to provide a fluent interface.
    */
-  def withBody(body: String): Self
+  def withBody(body: Body): Self
 
   /**
    * Execute the request and produce a response.

--- a/silhouette/src/main/scala/silhouette/http/client/RequestBuilder.scala
+++ b/silhouette/src/main/scala/silhouette/http/client/RequestBuilder.scala
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Minutemen Group under one or more contributor license
+ * agreements. See the COPYRIGHT file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package silhouette.http.client
+
+import scala.concurrent.Future
+
+/**
+ * Builds a request by providing a fluent interface.
+ *
+ * An instance of this class should not be instantiated directly. Instead the [[HttpClient]] should be
+ * used to instantiate the [[RequestBuilder]].
+ */
+private[silhouette] trait RequestBuilder {
+
+  /**
+   * The concrete implementation of this trait.
+   */
+  type Self <: RequestBuilder
+
+  /**
+   * Returns a copy of this instance with a new URL.
+   *
+   * @param url The URL to set.
+   * @return A request builder to provide a fluent interface.
+   */
+  def withUrl(url: String): Self
+
+  /**
+   * Returns a copy of this instance with a new HTTP method.
+   *
+   * @param method The HTTP method to set.
+   * @return A request builder to provide a fluent interface.
+   */
+  def withMethod(method: String): Self
+
+  /**
+   * Returns a copy of this instance with the list of headers set.
+   *
+   * @param headers The headers to set.
+   * @return A request builder to provide a fluent interface.
+   */
+  def withHeaders(headers: (String, String)*): Self
+
+  /**
+   * Returns a copy of this instance with the list of query params set.
+   *
+   * @param params The query params to set.
+   * @return A request builder to provide a fluent interface.
+   */
+  def withQueryParams(params: (String, String)*): Self
+
+  /**
+   * Returns a copy of this instance with a new body.
+   *
+   * @param body The body to set.
+   * @return A request builder to provide a fluent interface.
+   */
+  def withBody(body: String): Self
+
+  /**
+   * Execute the request and produce a response.
+   *
+   * @return The response.
+   */
+  def execute(): Future[Response]
+}

--- a/silhouette/src/main/scala/silhouette/http/client/Response.scala
+++ b/silhouette/src/main/scala/silhouette/http/client/Response.scala
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Minutemen Group under one or more contributor license
+ * agreements. See the COPYRIGHT file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package silhouette.http.client
+
+/**
+ * The response a HTTP client returns after a request.
+ */
+private[silhouette] trait Response {
+
+  /**
+   * Gets all headers.
+   *
+   * The HTTP RFC2616 allows duplicate response headers with the same name. Therefore we must define a
+   * header values as sequence of values.
+   *
+   * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
+   *
+   * @return All headers.
+   */
+  def header: Map[String, Seq[String]]
+
+  /**
+   * Returns the HTTP status code of this response.
+   *
+   * @return The HTTP status code.
+   */
+  def status: Int
+
+  /**
+   * Returns the content type of this response.
+   *
+   * @return The content type of the response.
+   */
+  def contentType: String
+
+  /**
+   * Returns the response body.
+   *
+   * @return The response body.
+   */
+  def body: String
+}

--- a/silhouette/src/main/scala/silhouette/http/client/Response.scala
+++ b/silhouette/src/main/scala/silhouette/http/client/Response.scala
@@ -53,5 +53,5 @@ private[silhouette] trait Response {
    *
    * @return The response body.
    */
-  def body: String
+  def body: Body
 }

--- a/silhouette/src/main/scala/silhouette/http/decoder/BodyDecoder.scala
+++ b/silhouette/src/main/scala/silhouette/http/decoder/BodyDecoder.scala
@@ -15,15 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Dependencies._
+package silhouette.http.decoder
 
-libraryDependencies ++= Seq(
-  Library.jsonAst,
-  Library.slf4jApi,
-  Library.inject,
-  Library.commonCodec,
-  Library.Circe.core,
-  Library.Circe.parser,
-  Library.scalaXml
-)
-enablePlugins(Doc)
+import silhouette.http.client.Body
+import silhouette.util.Decoder
+import scala.util.Try
+
+/**
+ * Represents a decode action that extract from [[silhouette.http.client.Body]] an instance of B.
+ *
+ * @tparam T The type target of decode action.
+ */
+trait BodyDecoder[T] extends Decoder[Body, Try[T]]
+
+/**
+ * The only aim of this object is to provide default implicit BodyDecoder,
+ * uses trait for provide lowest implicit conversion chain.
+ */
+object BodyDecoder extends DefaultBodyDecoder

--- a/silhouette/src/main/scala/silhouette/http/decoder/DefaultBodyDecoder.scala
+++ b/silhouette/src/main/scala/silhouette/http/decoder/DefaultBodyDecoder.scala
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Minutemen Group under one or more contributor license
+ * agreements. See the COPYRIGHT file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package silhouette.http.decoder
+
+import io.circe.{ Json, ParsingFailure }
+import io.circe.parser._
+import silhouette.exceptions.{ DecoderException, UnsupportedContentTypeException }
+import silhouette.http.client.{ Body, ContentTypes }
+import scala.util.{ Failure, Try }
+import scala.xml.NodeSeq
+import DefaultBodyDecoder._
+
+/**
+ * Provide implicit decoder for default value.
+ */
+trait DefaultBodyDecoder {
+  implicit def circeJsonDecoder: BodyDecoder[Json] = new BodyDecoder[Json] {
+    override def decode(in: Body): Try[Json] = in match {
+      case Body(ContentTypes.`application/json`, charset, bytes) =>
+        parse(new String(bytes, charset)).toTry.recover {
+          case e @ ParsingFailure(msg, underlying) => throw new DecoderException(msg, Option(e))
+        }
+      case Body(ct, _, _) =>
+        Failure(new UnsupportedContentTypeException(UnsupportedContentType.format(ContentTypes.`application/json`, ct)))
+    }
+  }
+
+  implicit def scalaXmlDecoder: BodyDecoder[NodeSeq] = new BodyDecoder[NodeSeq] {
+    override def decode(in: Body): Try[NodeSeq] = in match {
+      case Body(ContentTypes.`application/xml`, charset, bytes) =>
+        Try(scala.xml.XML.loadString(new String(bytes, charset))).recover {
+          case e: org.xml.sax.SAXParseException => throw new DecoderException(e.getMessage, Option(e))
+        }
+      case Body(ct, _, _) =>
+        Failure(new UnsupportedContentTypeException(UnsupportedContentType.format(ContentTypes.`application/xml`, ct)))
+    }
+  }
+
+  implicit def stringDecoder: BodyDecoder[String] = new BodyDecoder[String] {
+    override def decode(in: Body): Try[String] = in match {
+      case Body(_, charset, bytes) => Try(new String(bytes, charset))
+    }
+  }
+}
+
+/**
+ * The companion object.
+ */
+object DefaultBodyDecoder {
+
+  /**
+   * The error messages.
+   */
+  val UnsupportedContentType: String = "[Silhouette][DefaultBodyDecoder] Expected %s but found %s"
+
+}

--- a/silhouette/src/main/scala/silhouette/http/decoder/package.scala
+++ b/silhouette/src/main/scala/silhouette/http/decoder/package.scala
@@ -15,15 +15,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Dependencies._
+package silhouette.http
 
-libraryDependencies ++= Seq(
-  Library.jsonAst,
-  Library.slf4jApi,
-  Library.inject,
-  Library.commonCodec,
-  Library.Circe.core,
-  Library.Circe.parser,
-  Library.scalaXml
-)
-enablePlugins(Doc)
+import silhouette.http.client.Body
+import scala.util.Try
+
+/**
+ * This package contains decode feature.
+ */
+package object decoder {
+
+  /**
+   * Provides syntax via enrichment classes.
+   */
+  implicit final class DecoderOps[A <: Body](val wrapped: A) {
+
+    /**
+     * Provide method that decode from Body to a T.
+     *
+     * @param decoder Decoder instance able to decode.
+     * @tparam T The result type to decode.
+     * @return an instance of T or an error if the body couldn't be decoded.
+     */
+    def as[T](implicit decoder: BodyDecoder[T]): Try[T] = decoder.decode(wrapped)
+  }
+}

--- a/silhouette/src/main/scala/silhouette/util/Decoder.scala
+++ b/silhouette/src/main/scala/silhouette/util/Decoder.scala
@@ -15,15 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Dependencies._
+package silhouette.util
 
-libraryDependencies ++= Seq(
-  Library.jsonAst,
-  Library.slf4jApi,
-  Library.inject,
-  Library.commonCodec,
-  Library.Circe.core,
-  Library.Circe.parser,
-  Library.scalaXml
-)
-enablePlugins(Doc)
+/**
+ * Represents a decode action that extract from A an instance of B.
+ *
+ * @tparam A The raw data source of decode action.
+ * @tparam B The type target of decode action.
+ */
+trait Decoder[A, B] {
+
+  /**
+   * Decode from A to target B.
+   *
+   * @param in The raw data source of decode action.
+   * @return An instance of B.
+   */
+  def decode(in: A): B
+}

--- a/silhouette/src/main/scala/silhouette/util/Encoder.scala
+++ b/silhouette/src/main/scala/silhouette/util/Encoder.scala
@@ -15,15 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Dependencies._
+package silhouette.util
 
-libraryDependencies ++= Seq(
-  Library.jsonAst,
-  Library.slf4jApi,
-  Library.inject,
-  Library.commonCodec,
-  Library.Circe.core,
-  Library.Circe.parser,
-  Library.scalaXml
-)
-enablePlugins(Doc)
+/**
+ * Represents an encode action that transform an instance of A to B.
+ *
+ * @tparam A The data source of encode action.
+ * @tparam B The type target of encode action.
+ */
+trait Encoder[A, B] {
+
+  /**
+   * Encode from A to target B.
+   *
+   * @param in The data source of encode action.
+   * @return An instance of B.
+   */
+  def encode(in: A): B
+}

--- a/silhouette/src/test/scala/silhouette/http/decoder/DefaultBodyDecoderSpec.scala
+++ b/silhouette/src/test/scala/silhouette/http/decoder/DefaultBodyDecoderSpec.scala
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Minutemen Group under one or more contributor license
+ * agreements. See the COPYRIGHT file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package silhouette.http.decoder
+
+import java.nio.charset.StandardCharsets
+
+import io.circe.Json
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import silhouette.exceptions.{ DecoderException, UnsupportedContentTypeException }
+import silhouette.http.client.{ Body, ContentType, ContentTypes }
+
+import scala.util.Try
+import scala.xml.NodeSeq
+import DefaultBodyDecoder._
+
+/**
+ * Test case for the [[DefaultBodyDecoder]] class.
+ */
+class DefaultBodyDecoderSpec extends Specification {
+
+  "the infix 'as' function" should {
+    "decode a Body as string" in new Context {
+      validJsonBody.as[String] must beSuccessfulTry.withValue(validJson)
+    }
+
+    "decode a Body as json" in new Context {
+      validJsonBody.as[Json] must be equalTo io.circe.parser.parse(validJson).toTry
+    }
+
+    "decode a Body as xml" in new Context {
+      validXmlBody.as[NodeSeq] must be equalTo Try(scala.xml.XML.loadString(validXml))
+    }
+
+    "return a Failure on invalid json" in new Context {
+      invalidJsonBody.as[Json] must beFailedTry.withThrowable[DecoderException]
+    }
+
+    "return a Failure on invalid xml" in new Context {
+      invalidJsonBody.as[NodeSeq] must beFailedTry.withThrowable[DecoderException]
+    }
+
+    "return a Failure on unsupported cotent-type" in new Context {
+      def errorMsg(expected: ContentType, actual: ContentType): String = UnsupportedContentType.format(expected, actual)
+      validXmlBody.as[Json] must beFailedTry.like {
+        case e: UnsupportedContentTypeException =>
+          e.getMessage must be equalTo errorMsg(ContentTypes.`application/json`, ContentTypes.`application/xml`)
+      }
+      validJsonBody.as[NodeSeq] must beFailedTry.like {
+        case e: UnsupportedContentTypeException =>
+          e.getMessage must be equalTo errorMsg(ContentTypes.`application/xml`, ContentTypes.`application/json`)
+      }
+
+    }
+  }
+
+  /**
+   * The context.
+   */
+  trait Context extends Scope {
+    val validJson = "{\"a\": \"b\"}"
+    val invalidJson = "{a: }"
+    val validXml = "<a>b</a>"
+    val invalidXml = "<a>b<a>"
+
+    val validJsonBody = Body(
+      contentType = ContentTypes.`application/json`,
+      data = validJson.getBytes(StandardCharsets.UTF_8.toString)
+    )
+    val invalidJsonBody = Body(
+      contentType = ContentTypes.`application/json`,
+      data = invalidJson.getBytes(StandardCharsets.UTF_8.toString)
+    )
+    val validXmlBody = Body(
+      contentType = ContentTypes.`application/xml`,
+      data = validXml.getBytes(StandardCharsets.UTF_8.toString)
+    )
+    val invalidXmlBody = Body(
+      contentType = ContentTypes.`application/xml`,
+      data = invalidXml.getBytes(StandardCharsets.UTF_8.toString)
+    )
+  }
+}


### PR DESCRIPTION
Add API for HttpClient which can be used to process HTTP requests. The concrete implementation of this client must be implemented by the framework specific Silhouette binding. The client is no full-blown HTTP client implementation. It implements only the parts which Silhouette depends on, and it is only meant for internal usage.


