### PR TITLE
Implement JWT generator with jose4j

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: scala
 scala:
 - 2.11.8
-- 2.12.0
+- 2.12.1
 jdk:
 - oraclejdk8
 env:

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,7 +19,7 @@ import sbt.Keys._
 import sbt._
 
 object Build extends Build {
-  lazy val buildVersions = taskKey[Unit]("Show some build versions")
+  lazy val buildVersions: TaskKey[Unit] = taskKey[Unit]("Show some build versions")
 
   val silhouetteSpecs2 = Project(
     id = "silhouette-specs2",
@@ -32,9 +32,15 @@ object Build extends Build {
     dependencies = Seq(silhouetteSpecs2 % Test)
   )
 
-  lazy val silhouetteCryptoJca = Project(
+  val silhouetteCryptoJca = Project(
     id = "silhouette-crypto-jca",
     base = file("silhouette-crypto-jca"),
+    dependencies = Seq(silhouette, silhouetteSpecs2 % Test)
+  )
+
+  val silhouetteJwtJose4j = Project(
+    id = "silhouette-jwt-jose4j",
+    base = file("silhouette-jwt-jose4j"),
     dependencies = Seq(silhouette, silhouetteSpecs2 % Test)
   )
 
@@ -56,12 +62,12 @@ object Build extends Build {
     aggregate = Seq(
       silhouette,
       silhouetteCryptoJca,
+      silhouetteJwtJose4j,
       silhouetteSpecs2,
       silhouettePasswordBcrypt,
       silhouettePersistence
     ),
     settings = Defaults.coreDefaultSettings ++
-      APIDoc.settings ++
       Seq(
         publish := {},
         buildVersions := {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,5 +45,8 @@ object Dependencies {
     val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.13"
     val inject = "javax.inject" % "javax.inject" % "1"
     val commonCodec = "commons-codec" % "commons-codec" % "1.10"
+    val jose4j = "org.bitbucket.b_c" % "jose4j" % "0.5.4"
+    val jsonAst = "org.mdedetrich" %% "scala-json-ast" % "1.0.0-M4"
+    val bouncyCastle = "org.bouncycastle" % "bcprov-jdk15on" % "1.56"
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,3 +19,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "latest.release")

--- a/silhouette-jwt-jose4j/build.sbt
+++ b/silhouette-jwt-jose4j/build.sbt
@@ -18,10 +18,8 @@
 import Dependencies._
 
 libraryDependencies ++= Seq(
-  Library.Specs2.core,
-  Library.Specs2.matcherExtra,
-  Library.Specs2.mock,
-  Library.mockito,
-  Library.bouncyCastle
+  Library.jose4j,
+  Library.bouncyCastle % Test
 )
+
 enablePlugins(Doc)

--- a/silhouette-jwt-jose4j/src/main/scala/silhouette/jwt/Jose4jJwt.scala
+++ b/silhouette-jwt-jose4j/src/main/scala/silhouette/jwt/Jose4jJwt.scala
@@ -1,0 +1,237 @@
+/**
+ * Licensed to the Minutemen Group under one or more contributor license
+ * agreements. See the COPYRIGHT file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package silhouette.jwt
+
+import org.jose4j.jws.AlgorithmIdentifiers._
+import org.jose4j.jws.JsonWebSignature
+import org.jose4j.jwt.consumer.JwtConsumerBuilder
+import org.jose4j.jwt.{ JwtClaims => JJwtClaims }
+
+import scala.util.Try
+
+/**
+ * Concrete implementations for the Jose4j JWT implementation.
+ */
+object Jose4jJwt {
+
+  /**
+   * HMAC based algorithms.
+   */
+  case object HS256 extends JwsHmacAlgorithm[String] { def get: String = HMAC_SHA256 }
+  case object HS384 extends JwsHmacAlgorithm[String] { def get: String = HMAC_SHA384 }
+  case object HS512 extends JwsHmacAlgorithm[String] { def get: String = HMAC_SHA512 }
+
+  /**
+   * Asymmetric RSA cryptography based algorithms.
+   */
+  case object RS256 extends JwsRsaAlgorithm[String] { def get: String = RSA_USING_SHA256 }
+  case object RS384 extends JwsRsaAlgorithm[String] { def get: String = RSA_USING_SHA384 }
+  case object RS512 extends JwsRsaAlgorithm[String] { def get: String = RSA_USING_SHA512 }
+
+  /**
+   * Asymmetric EC(elliptic-curve) cryptography based algorithms.
+   */
+  case object ES256 extends JwsEcAlgorithm[String] { def get: String = ECDSA_USING_P256_CURVE_AND_SHA256 }
+  case object ES384 extends JwsEcAlgorithm[String] { def get: String = ECDSA_USING_P384_CURVE_AND_SHA384 }
+  case object ES512 extends JwsEcAlgorithm[String] { def get: String = ECDSA_USING_P521_CURVE_AND_SHA512 }
+
+  /**
+   * Asymmetric RSA-PSS cryptography based algorithms.
+   *
+   * This algorithms requires the Bouncy Castle JCA provider (or another provider which supports RSASSA-PSS).
+   */
+  case object PS256 extends JwsRsaPssAlgorithm[String] { def get: String = RSA_PSS_USING_SHA256 }
+  case object PS384 extends JwsRsaPssAlgorithm[String] { def get: String = RSA_PSS_USING_SHA384 }
+  case object PS512 extends JwsRsaPssAlgorithm[String] { def get: String = RSA_PSS_USING_SHA512 }
+
+  /**
+   * A simple JWT producer which supports common JWS algorithms.
+   *
+   * @param jwsConfiguration The JWS configuration.
+   */
+  class SimpleProducer(jwsConfiguration: JwsConfiguration[String]) extends Jose4jJwtProducer {
+
+    /**
+     * Produces claims and returns a JWT as string.
+     *
+     * @param claims The claims to produce.
+     * @return The produced JWT string.
+     */
+    override def produce(claims: JJwtClaims): String = {
+      val jws = new JsonWebSignature()
+      jws.setPayload(claims.toJson)
+      jwsConfiguration match {
+        case JwsHmacConfiguration(algorithm, key) =>
+          jws.setAlgorithmHeaderValue(algorithm.get)
+          jws.setKey(key)
+        case JwsRsaConfiguration(algorithm, _, privateKey) =>
+          jws.setAlgorithmHeaderValue(algorithm.get)
+          jws.setKey(privateKey)
+        case JwsEcConfiguration(algorithm, _, privateKey) =>
+          jws.setAlgorithmHeaderValue(algorithm.get)
+          jws.setKey(privateKey)
+        case JwsRsaPssConfiguration(algorithm, _, privateKey) =>
+          jws.setAlgorithmHeaderValue(algorithm.get)
+          jws.setKey(privateKey)
+      }
+      jws.getCompactSerialization
+    }
+  }
+
+  /**
+   * A simple JWT consumer which supports common JWS algorithms.
+   *
+   * @param configuration The consumer configuration.
+   */
+  class SimpleConsumer(configuration: SimpleConsumerConfiguration) extends Jose4jJwtConsumer {
+    type BuilderPipeline = PartialFunction[JwtConsumerBuilder, JwtConsumerBuilder]
+
+    /**
+     * Consumes a JWT and returns [[org.jose4j.jwt.JwtClaims]].
+     *
+     * @param jwt The JWT token to consume.
+     * @return The [[org.jose4j.jwt.JwtClaims]] extracted from the JWT token on success, otherwise an failure.
+     */
+    override def consume(jwt: String): Try[JJwtClaims] = {
+      Try(new JwtConsumerBuilder())
+        .map(jws)
+        .map(requireSubject)
+        .map(requireJwtID)
+        .map(requireExpirationTime)
+        .map(requireIssuedAt)
+        .map(requireNotBefore)
+        .map(expectedIssuer)
+        .map(expectedAudience)
+        .map(_.build().processToClaims(jwt))
+    }
+
+    /**
+     * Maps the `jws` configuration to the [[org.jose4j.jwt.consumer.JwtConsumerBuilder]].
+     *
+     * @return The builder pipeline.
+     */
+    private def jws: BuilderPipeline = {
+      case builder =>
+        configuration.jws match {
+          case JwsHmacConfiguration(_, key) =>
+            builder.setVerificationKey(key)
+          case JwsRsaConfiguration(_, publicKey, _) =>
+            builder.setVerificationKey(publicKey)
+          case JwsEcConfiguration(_, publicKey, _) =>
+            builder.setVerificationKey(publicKey)
+          case JwsRsaPssConfiguration(_, publicKey, _) =>
+            builder.setVerificationKey(publicKey)
+        }
+    }
+
+    /**
+     * Maps the `requireSubject` configuration to the [[org.jose4j.jwt.consumer.JwtConsumerBuilder]].
+     *
+     * @return The builder pipeline.
+     */
+    private def requireSubject: BuilderPipeline = {
+      case builder if configuration.requireSubject => builder.setRequireSubject()
+      case builder                                 => builder
+    }
+
+    /**
+     * Maps the `requireJwtID` configuration to the [[org.jose4j.jwt.consumer.JwtConsumerBuilder]].
+     *
+     * @return The builder pipeline.
+     */
+    private def requireJwtID: BuilderPipeline = {
+      case builder if configuration.requireJwtID => builder.setRequireJwtId()
+      case builder                               => builder
+    }
+
+    /**
+     * Maps the `requireExpirationTime` configuration to the [[org.jose4j.jwt.consumer.JwtConsumerBuilder]].
+     *
+     * @return The builder pipeline.
+     */
+    private def requireExpirationTime: BuilderPipeline = {
+      case builder if configuration.requireExpirationTime => builder.setRequireExpirationTime()
+      case builder                                        => builder
+    }
+
+    /**
+     * Maps the `requireIssuedAt` configuration to the [[org.jose4j.jwt.consumer.JwtConsumerBuilder]].
+     *
+     * @return The builder pipeline.
+     */
+    private def requireIssuedAt: BuilderPipeline = {
+      case builder if configuration.requireIssuedAt => builder.setRequireIssuedAt()
+      case builder                                  => builder
+    }
+
+    /**
+     * Maps the `requireNotBefore` configuration to the [[org.jose4j.jwt.consumer.JwtConsumerBuilder]].
+     *
+     * @return The builder pipeline.
+     */
+    private def requireNotBefore: BuilderPipeline = {
+      case builder if configuration.requireNotBefore => builder.setRequireNotBefore()
+      case builder                                   => builder
+    }
+
+    /**
+     * Maps the `expectedIssuer` configuration to the [[org.jose4j.jwt.consumer.JwtConsumerBuilder]].
+     *
+     * @return The builder pipeline.
+     */
+    private def expectedIssuer: BuilderPipeline = {
+      case builder =>
+        configuration.expectedIssuer.map(issuer => builder.setExpectedIssuer(issuer)).getOrElse(builder)
+    }
+
+    /**
+     * Maps the `expectedAudience` configuration to the [[org.jose4j.jwt.consumer.JwtConsumerBuilder]].
+     *
+     * @return The builder pipeline.
+     */
+    private def expectedAudience: BuilderPipeline = {
+      case builder =>
+        configuration.expectedAudience.map(audience => builder.setExpectedAudience(audience: _*)).getOrElse(builder)
+    }
+  }
+
+  /**
+   * The simple consumer configuration.
+   *
+   * @param jws                   The JWS configuration.
+   * @param requireSubject        Indicates if the 'sub' claim must be set during JWT consumption.
+   * @param requireJwtID          Indicates if the 'jti' claim must be set during JWT consumption.
+   * @param requireExpirationTime Indicates if the 'exp' claim must be set during JWT consumption.
+   * @param requireIssuedAt       Indicates if the 'iat' claim must be set during JWT consumption.
+   * @param requireNotBefore      Indicates if the 'nbf' claim must be set during JWT consumption.
+   * @param expectedIssuer        Indicates the expected value of the issuer ("iss") claim and that the claim is
+   *                              required.
+   * @param expectedAudience      Set the audience value(s) to use when validating the audience ("aud") claim of a JWT
+   *                              and require that an audience claim be present.
+   */
+  case class SimpleConsumerConfiguration(
+    jws: JwsConfiguration[String],
+    requireSubject: Boolean = false,
+    requireJwtID: Boolean = false,
+    requireExpirationTime: Boolean = false,
+    requireIssuedAt: Boolean = false,
+    requireNotBefore: Boolean = false,
+    expectedIssuer: Option[String] = None,
+    expectedAudience: Option[List[String]] = None
+  )
+}

--- a/silhouette-jwt-jose4j/src/main/scala/silhouette/jwt/Jose4jJwtGenerator.scala
+++ b/silhouette-jwt-jose4j/src/main/scala/silhouette/jwt/Jose4jJwtGenerator.scala
@@ -1,0 +1,229 @@
+/**
+ * Licensed to the Minutemen Group under one or more contributor license
+ * agreements. See the COPYRIGHT file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package silhouette.jwt
+
+import org.jose4j.jwt.consumer.JwtConsumerBuilder
+import org.jose4j.jwt.{ NumericDate, JwtClaims => JJwtClaims }
+import org.jose4j.jwx.JsonWebStructure
+import silhouette.exceptions.JwtException
+import silhouette.jwt.Jose4jJwtGenerator._
+
+import scala.collection.JavaConverters._
+import scala.json.ast._
+import scala.util.{ Failure, Try }
+
+/**
+ * JWT encoder/decoder which is based on the [jose4j](https://bitbucket.org/b_c/jose4j/wiki/Home) library.
+ *
+ * The library supports the JWS/JWE compact serializations with the complete suite of JOSE algorithms.
+ *
+ * @param producer The JWT producer.
+ * @param consumer The JWT consumer.
+ */
+final class Jose4jJwtGenerator(
+  producer: Jose4jJwtProducer,
+  consumer: Jose4jJwtConsumer)
+  extends JwtGenerator {
+
+  /**
+   * Monkey patch the [org.jose4j.jwt.JwtClaims] instance.
+   *
+   * @param claims The jose4j claims instance to convert.
+   */
+  private implicit class RichJJwtClaims(claims: JJwtClaims) {
+
+    /**
+     * Converts the jose4j claims instance to a Silhouette claims instance.
+     *
+     * @return The Silhouette claims instance.
+     */
+    def toSilhouette: JwtClaims = {
+      JwtClaims(
+        issuer = Option(claims.getIssuer),
+        subject = Option(claims.getSubject),
+        audience = Option(claims.getAudience).map(_.asScala.toList) match {
+          case Some(Nil) => None
+          case s         => s
+        },
+        expirationTime = Option(claims.getExpirationTime).map(_.getValue),
+        notBefore = Option(claims.getNotBefore).map(_.getValue),
+        issuedAt = Option(claims.getIssuedAt).map(_.getValue),
+        jwtID = Option(claims.getJwtId),
+        custom = claims.getClaimsMap(ReservedClaims.asJava).asScala match {
+          case l if l.isEmpty => JObject()
+          case l              => decodeCustomClaims(l.asJava)
+        }
+      )
+    }
+  }
+
+  /**
+   * Monkey patch the [JwtClaims] instance.
+   *
+   * @param claims The Silhouette claims instance to convert.
+   * @return The jose4j claims instance.
+   */
+  private implicit class RichJwtClaims(claims: JwtClaims) {
+
+    /**
+     * Converts the Silhouette claims instance to a jose4j claims instance.
+     *
+     * @return The jose4j claims instance.
+     */
+    def toJose4j: JJwtClaims = {
+      val result = new JJwtClaims()
+      claims.issuer.foreach(result.setIssuer)
+      claims.subject.foreach(result.setSubject)
+      claims.audience.foreach(v => result.setAudience(v.asJava))
+      claims.expirationTime.foreach(v => result.setExpirationTime(NumericDate.fromSeconds(v)))
+      claims.notBefore.foreach(v => result.setNotBefore(NumericDate.fromSeconds(v)))
+      claims.issuedAt.foreach(v => result.setIssuedAt(NumericDate.fromSeconds(v)))
+      claims.jwtID.foreach(result.setJwtId)
+      encodeCustomClaims(claims.custom).asScala.foreach {
+        case (k, v) =>
+          if (ReservedClaims.contains(k)) {
+            throw new JwtException(OverrideReservedClaim.format(k, ReservedClaims.mkString(", ")))
+          }
+          result.setClaim(k, v)
+      }
+      result
+    }
+  }
+
+  /**
+   * Encodes a JWT claims object and returns a JWT as string.
+   *
+   * @param jwt The JWT claims object to encode.
+   * @return The JWT string representation or an error if the JWT claims object couldn't be encoded.
+   */
+  override def encode(jwt: JwtClaims): Try[String] = Try(producer.produce(jwt.toJose4j))
+
+  /**
+   * Decodes a JWT string and returns a JWT claims object.
+   *
+   * @param str A JWT string.
+   * @return The decoded JWT claims object or an error if the string couldn't be decoded.
+   */
+  override def decode(str: String): Try[JwtClaims] = {
+    consumer.consume(str).map(_.toSilhouette).recoverWith {
+      case e =>
+        Failure(new JwtException(FraudulentJwtToken.format(str), Some(e)))
+    }
+  }
+
+  /**
+   * Encodes recursively the custom claims.
+   *
+   * @param claims The custom claims to encode.
+   * @return A map containing custom claims.
+   */
+  private def encodeCustomClaims(claims: JObject): java.util.Map[String, Object] = {
+    def toJava(value: JValue): Object = value match {
+      case JNull       => None.orNull
+      case v: JString  => v.value
+      case v: JNumber  => BigDecimal(v.value)
+      case v: JBoolean => Boolean.box(v.get)
+      case v: JArray   => v.value.map(toJava).asJava
+      case v: JObject  => encodeCustomClaims(v)
+    }
+
+    claims.value.map { case (name, value) => name -> toJava(value) }.asJava
+  }
+
+  /**
+   * Decodes recursively the custom claims.
+   *
+   * @param claims The custom claims to decode.
+   * @return A Json object representing the custom claims.
+   */
+  private def decodeCustomClaims(claims: java.util.Map[String, Object]): JObject = {
+    def toJson(value: Any): JValue = Option(value) match {
+      case None                         => JNull
+      case Some(v: java.lang.String)    => JString(v)
+      case Some(v: java.lang.Number)    => JNumber(v.toString)
+      case Some(v: java.lang.Boolean)   => JBoolean(v)
+      case Some(v: java.util.List[_])   => JArray(v.asScala.toVector.map(toJson))
+      case Some(v: java.util.Map[_, _]) => decodeCustomClaims(v.asInstanceOf[java.util.Map[String, Object]])
+      case Some(v)                      => throw new JwtException(UnexpectedJsonValue.format(v))
+    }
+
+    JObject(claims.asScala.toMap.map { case (name, value) => name -> toJson(value) })
+  }
+}
+
+/**
+ * The companion object.
+ */
+object Jose4jJwtGenerator {
+
+  /**
+   * The reserved claims.
+   */
+  val ReservedClaims: Set[String] = Set("iss", "sub", "aud", "exp", "nbf", "iat", "jti")
+
+  /**
+   * The error messages.
+   */
+  val FraudulentJwtToken: String = "[Silhouette][Jose4jJwtGenerator] Fraudulent JWT token: %s"
+  val OverrideReservedClaim: String = "[Silhouette][Jose4jJwtGenerator] Try to overriding a reserved claim `%s`; " +
+    "list of reserved claims: %s"
+  val UnexpectedJsonValue: String = "[Silhouette][Jose4jJwtGenerator] Unexpected Json value: %s"
+}
+
+/**
+ * Produces JWT tokens with the help of the [jose4j](https://bitbucket.org/b_c/jose4j/wiki/Home) library.
+ *
+ * The production of a JWT can be very complex, especially with the jose4j library because of it's feature richness.
+ * A JWT can use different encryption and signing algorithms, it can be nested or it can use the two-pass consumption
+ * approach. Therefore we allow a user to define it's own [[org.jose4j.jwx.JsonWebStructure]] implementation for the
+ * given claims.
+ *
+ * Please visit the [documentation](https://bitbucket.org/b_c/jose4j/wiki/JWT%20Examples) to see how a
+ * [[org.jose4j.jwe.JsonWebEncryption]] or a [[org.jose4j.jws.JsonWebSignature]] can be configured.
+ */
+trait Jose4jJwtProducer {
+
+  /**
+   * Produces claims and returns a JWT as string.
+   *
+   * @param claims The claims to produce.
+   * @return The produced JWT string.
+   */
+  def produce(claims: JJwtClaims): String
+}
+
+/**
+ * Consumes JWT tokens with the help of the [jose4j](https://bitbucket.org/b_c/jose4j/wiki/Home) library.
+ *
+ * The consumption of a JWT can be very complex, especially with the jose4j library because of it's feature richness.
+ * A JWT can use different encryption and signing algorithms, it can be nested or it can use the two-pass consumption
+ * approach. Therefore we allow a user to define it's own [[org.jose4j.jwt.consumer.JwtConsumerBuilder]].
+ *
+ * Please visit the [documentation](https://bitbucket.org/b_c/jose4j/wiki/JWT%20Examples) to see how the
+ * [[org.jose4j.jwt.consumer.JwtConsumerBuilder]] can be configured.
+ */
+trait Jose4jJwtConsumer {
+
+  /**
+   * Consumes a JWT and returns [[org.jose4j.jwt.JwtClaims]].
+   *
+   * @param jwt The JWT token to consume.
+   * @return The [[org.jose4j.jwt.JwtClaims]] extracted from the JWT token on success, otherwise an failure.
+   */
+  def consume(jwt: String): Try[JJwtClaims]
+}

--- a/silhouette-jwt-jose4j/src/test/scala/silhouette/jwt/Jose4jJwtGeneratorSpec.scala
+++ b/silhouette-jwt-jose4j/src/test/scala/silhouette/jwt/Jose4jJwtGeneratorSpec.scala
@@ -1,0 +1,211 @@
+/**
+ * Licensed to the Minutemen Group under one or more contributor license
+ * agreements. See the COPYRIGHT file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package silhouette.jwt
+
+import java.time.ZonedDateTime
+
+import org.jose4j.jwa.AlgorithmConstraints
+import org.jose4j.jws.AlgorithmIdentifiers._
+import org.jose4j.jws.JsonWebSignature
+import org.jose4j.jwt.consumer.JwtConsumerBuilder
+import org.jose4j.jwt.{ JwtClaims => JJwtClaims }
+import org.specs2.matcher.MatchResult
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import silhouette.exceptions.JwtException
+import silhouette.jwt.Jose4jJwtGenerator._
+import silhouette.specs2.WithBouncyCastle
+
+import scala.json.ast._
+import scala.util.Try
+
+/**
+ * Test case for the [[Jose4jJwtGenerator]] class.
+ */
+class Jose4jJwtGeneratorSpec extends Specification with WithBouncyCastle {
+
+  "The `generator`" should {
+    "generate a JWT with an `iss` claim" in new Context {
+      generate(JwtClaims(issuer = Some("test")))
+    }
+
+    "generate a JWT with a `sub` claim" in new Context {
+      generate(JwtClaims(subject = Some("test")))
+    }
+
+    "generate a JWT with an `aud` claim" in new Context {
+      generate(JwtClaims(audience = Some(List("test1", "test2"))))
+    }
+
+    "generate a JWT with an `exp` claim" in new Context {
+      generate(JwtClaims(expirationTime = Some(ZonedDateTime.now().toEpochSecond)))
+    }
+
+    "generate a JWT with a `nbf` claim" in new Context {
+      generate(JwtClaims(notBefore = Some(ZonedDateTime.now().toEpochSecond)))
+    }
+
+    "generate a JWT with an `iat` claim" in new Context {
+      generate(JwtClaims(issuedAt = Some(ZonedDateTime.now().toEpochSecond)))
+    }
+
+    "generate a JWT with a `jti` claim" in new Context {
+      generate(JwtClaims(jwtID = Some("test")))
+    }
+
+    "generate a JWT with custom claims" in new Context {
+      generate(JwtClaims(custom = customClaims))
+    }
+
+    "generate a complex JWT" in new Context {
+      generate(JwtClaims(
+        issuer = Some("test"),
+        subject = Some("test"),
+        audience = Some(List("test1", "test2")),
+        expirationTime = Some(ZonedDateTime.now().toEpochSecond),
+        notBefore = Some(ZonedDateTime.now().toEpochSecond),
+        issuedAt = Some(ZonedDateTime.now().toEpochSecond),
+        jwtID = Some("test"),
+        custom = customClaims
+      ))
+    }
+  }
+
+  "The `encode` method" should {
+    "throw a JwtException if a custom claim tries to override the reserved claim `iss`" in new Context {
+      reserved("iss")
+    }
+
+    "throw a JwtException if a custom claim tries to override the reserved claim `sub`" in new Context {
+      reserved("sub")
+    }
+
+    "throw a JwtException if a custom claim tries to override the reserved claim `aud`" in new Context {
+      reserved("aud")
+    }
+
+    "throw a JwtException if a custom claim tries to override the reserved claim `exp`" in new Context {
+      reserved("exp")
+    }
+
+    "throw a JwtException if a custom claim tries to override the reserved claim `nbf`" in new Context {
+      reserved("nbf")
+    }
+
+    "throw a JwtException if a custom claim tries to override the reserved claim `iat`" in new Context {
+      reserved("iat")
+    }
+
+    "throw a JwtException if a custom claim tries to override the reserved claim `jti`" in new Context {
+      reserved("jti")
+    }
+  }
+
+  "The `decode` method" should {
+    "throw a JwtException if an error occurred during decoding" in new Context {
+      generator.decode("invalid.token") must beFailedTry.like {
+        case e: JwtException => e.getMessage must be equalTo FraudulentJwtToken.format("invalid.token")
+      }
+    }
+  }
+
+  /**
+   * The context.
+   */
+  trait Context extends Scope {
+
+    /**
+     * A simple producer for testing.
+     */
+    val producer = new Jose4jJwtProducer {
+      override def produce(claims: JJwtClaims): String = {
+        val jws = new JsonWebSignature()
+        jws.setAlgorithmConstraints(AlgorithmConstraints.NO_CONSTRAINTS)
+        jws.setPayload(claims.toJson)
+        jws.setAlgorithmHeaderValue(NONE)
+        jws.getCompactSerialization
+      }
+    }
+
+    /**
+     * A simple consumer for testing.
+     */
+    val consumer = new Jose4jJwtConsumer {
+      override def consume(jwt: String): Try[JJwtClaims] = {
+        Try(new JwtConsumerBuilder())
+          .map(builder => builder.setJwsAlgorithmConstraints(AlgorithmConstraints.NO_CONSTRAINTS))
+          .map(builder => builder.setDisableRequireSignature())
+          .map(builder => builder.setSkipAllValidators())
+          .map(builder => builder.setSkipAllDefaultValidators())
+          .map(_.build().processToClaims(jwt))
+      }
+    }
+
+    /**
+     * The generator to test.
+     */
+    val generator = new Jose4jJwtGenerator(producer, consumer)
+
+    /**
+     * Some custom claims.
+     */
+    lazy val customClaims = JObject(Map(
+      "boolean" -> JTrue,
+      "string" -> JString("string"),
+      "int" -> JNumber(1234567890),
+      "long" -> JNumber(1234567890L),
+      "float" -> JNumber(1.2),
+      "double" -> JNumber(1.2d),
+      "null" -> JNull,
+      "array" -> JArray(JNumber(1), JNumber(2)),
+      "object" -> JObject(Map(
+        "array" -> JArray(JString("string1"), JString("string2")),
+        "object" -> JObject(Map(
+          "array" -> JArray(JString("string"), JFalse, JObject(Map("number" -> JNumber(1))))
+        ))
+      ))
+    ))
+
+    /**
+     * A helper method which encodes claims into a JWT and then decodes the JWT to check if the same
+     * claims were decoded.
+     *
+     * @param claims The claims to check for.
+     * @return A Specs2 match result.
+     */
+    protected def generate(claims: JwtClaims): MatchResult[Any] = {
+      generator.encode(claims) must beSuccessfulTry.like {
+        case jwt =>
+          generator.decode(jwt) must beSuccessfulTry.withValue(claims)
+      }
+    }
+
+    /**
+     * A helper method which overrides reserved claims and checks for an exception.
+     *
+     * @param claim The claim to override.
+     * @return A Specs2 match result.
+     */
+    protected def reserved(claim: String): MatchResult[Any] = {
+      val message = OverrideReservedClaim.format(claim, ReservedClaims.mkString(", "))
+      generator.encode(JwtClaims(custom = JObject(Map(claim -> JString("test"))))) must beFailedTry.like {
+        case e: JwtException => e.getMessage must be equalTo message
+      }
+    }
+  }
+}

--- a/silhouette-jwt-jose4j/src/test/scala/silhouette/jwt/Jose4jJwtSpec.scala
+++ b/silhouette-jwt-jose4j/src/test/scala/silhouette/jwt/Jose4jJwtSpec.scala
@@ -1,0 +1,249 @@
+/**
+ * Licensed to the Minutemen Group under one or more contributor license
+ * agreements. See the COPYRIGHT file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package silhouette.jwt
+
+import org.jose4j.jwk.{ EcJwkGenerator, RsaJwkGenerator }
+import org.jose4j.keys.{ EllipticCurves, HmacKey }
+import org.specs2.matcher.MatchResult
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import silhouette.crypto.Hash._
+import silhouette.exceptions.JwtException
+import silhouette.jwt.Jose4jJwt._
+import silhouette.jwt.Jose4jJwtGenerator._
+import silhouette.specs2.WithBouncyCastle
+
+/**
+ * Test case for the [[Jose4jJwt]] default implementations.
+ */
+class Jose4jJwtSpec extends Specification with Mockito with WithBouncyCastle {
+
+  "The `generator`" should {
+    "generate a JWT with the `HS256` algorithm" in new Context {
+      override val jwsConfiguration = JwsHmacConfiguration(HS256, new HmacKey(sha256("some.secret")))
+
+      generate(claims)
+    }
+
+    "generate a JWT with the `HS384` algorithm" in new Context {
+      override val jwsConfiguration = JwsHmacConfiguration(HS384, new HmacKey(sha384("some.secret")))
+
+      generate(claims)
+    }
+
+    "generate a JWT with the `HS512` algorithm" in new Context {
+      override val jwsConfiguration = JwsHmacConfiguration(HS512, new HmacKey(sha512("some.secret")))
+
+      generate(claims)
+    }
+
+    "generate a JWT with the `RS256` algorithm" in new Context {
+      override val jwsConfiguration = JwsRsaConfiguration(RS256, rsaJwk.getRsaPublicKey, rsaJwk.getRsaPrivateKey)
+
+      generate(claims)
+    }
+
+    "generate a JWT with the `RS384` algorithm" in new Context {
+      override val jwsConfiguration = JwsRsaConfiguration(RS384, rsaJwk.getRsaPublicKey, rsaJwk.getRsaPrivateKey)
+
+      generate(claims)
+    }
+
+    "generate a JWT with the `RS512` algorithm" in new Context {
+      override val jwsConfiguration = JwsRsaConfiguration(RS512, rsaJwk.getRsaPublicKey, rsaJwk.getRsaPrivateKey)
+
+      generate(claims)
+    }
+
+    "generate a JWT with the `ES256` algorithm" in new Context {
+      override val ecParameterSpec = EllipticCurves.P256
+      override val jwsConfiguration = JwsEcConfiguration(ES256, ecJwk.getECPublicKey, ecJwk.getEcPrivateKey)
+
+      generate(claims)
+    }
+
+    "generate a JWT with the `ES384` algorithm" in new Context {
+      override val ecParameterSpec = EllipticCurves.P384
+      override val jwsConfiguration = JwsEcConfiguration(ES384, ecJwk.getECPublicKey, ecJwk.getEcPrivateKey)
+
+      generate(claims)
+    }
+
+    "generate a JWT with the `ES512` algorithm" in new Context {
+      override val ecParameterSpec = EllipticCurves.P521
+      override val jwsConfiguration = JwsEcConfiguration(ES512, ecJwk.getECPublicKey, ecJwk.getEcPrivateKey)
+
+      generate(claims)
+    }
+
+    "generate a JWT with the `PS256` algorithm" in new Context {
+      override val jwsConfiguration = JwsRsaPssConfiguration(PS256, rsaJwk.getRsaPublicKey, rsaJwk.getRsaPrivateKey)
+
+      generate(claims)
+    }
+
+    "generate a JWT with the `PS384` algorithm" in new Context {
+      override val jwsConfiguration = JwsRsaPssConfiguration(PS384, rsaJwk.getRsaPublicKey, rsaJwk.getRsaPrivateKey)
+
+      generate(claims)
+    }
+
+    "generate a JWT with the `PS512` algorithm" in new Context {
+      override val jwsConfiguration = JwsRsaPssConfiguration(PS512, rsaJwk.getRsaPublicKey, rsaJwk.getRsaPrivateKey)
+
+      generate(claims)
+    }
+  }
+
+  "The `consumer`" should {
+    "throw an JwtException if the 'sub' claim is required but missed" in new Context {
+      override val jwsConfiguration = JwsHmacConfiguration(HS256, new HmacKey(sha256("some.secret")))
+      simpleConsumerConfiguration.requireSubject returns true
+
+      fraudulent(JwtClaims())
+    }
+
+    "throw an JwtException if the 'jti' claim is required but missed" in new Context {
+      override val jwsConfiguration = JwsHmacConfiguration(HS256, new HmacKey(sha256("some.secret")))
+      simpleConsumerConfiguration.requireJwtID returns true
+
+      fraudulent(JwtClaims())
+    }
+
+    "throw an JwtException if the 'exp' claim is required but missed" in new Context {
+      override val jwsConfiguration = JwsHmacConfiguration(HS256, new HmacKey(sha256("some.secret")))
+      simpleConsumerConfiguration.requireExpirationTime returns true
+
+      fraudulent(JwtClaims())
+    }
+
+    "throw an JwtException if the 'iat' claim is required but missed" in new Context {
+      override val jwsConfiguration = JwsHmacConfiguration(HS256, new HmacKey(sha256("some.secret")))
+      simpleConsumerConfiguration.requireIssuedAt returns true
+
+      fraudulent(JwtClaims())
+    }
+
+    "throw an JwtException if the 'nbf' claim is required but missed" in new Context {
+      override val jwsConfiguration = JwsHmacConfiguration(HS256, new HmacKey(sha256("some.secret")))
+      simpleConsumerConfiguration.requireNotBefore returns true
+
+      fraudulent(JwtClaims())
+    }
+
+    "throw an JwtException if the expected issuer is not available in the JWT" in new Context {
+      override val jwsConfiguration = JwsHmacConfiguration(HS256, new HmacKey(sha256("some.secret")))
+      simpleConsumerConfiguration.expectedIssuer returns Some("test1")
+
+      fraudulent(JwtClaims(issuer = Some("test2")))
+    }
+
+    "throw an JwtException if the expected audience is not available in the JWT" in new Context {
+      override val jwsConfiguration = JwsHmacConfiguration(HS256, new HmacKey(sha256("some.secret")))
+      simpleConsumerConfiguration.expectedAudience returns Some(List("test1", "test2"))
+
+      fraudulent(JwtClaims(audience = Some(List("test3"))))
+    }
+  }
+
+  /**
+   * The context.
+   */
+  trait Context extends Scope {
+
+    /**
+     * The test claims.
+     */
+    val claims = JwtClaims(issuer = Some("test"))
+
+    /**
+     * The JWS configuration.
+     */
+    val jwsConfiguration: JwsConfiguration[String]
+
+    /**
+     * The EC parameter spec.
+     */
+    val ecParameterSpec = EllipticCurves.P256
+
+    /**
+     * A RSA JWK.
+     *
+     * This is used to generate a key pair for RSA based algorithms.
+     */
+    lazy val rsaJwk = RsaJwkGenerator.generateJwk(2048)
+
+    /**
+     * A EC JWK.
+     *
+     * This is used to generate a key pair for EC based algorithms.
+     */
+    lazy val ecJwk = EcJwkGenerator.generateJwk(ecParameterSpec)
+
+    /**
+     * The simple consumer configuration.
+     */
+    lazy val simpleConsumerConfiguration = spy(SimpleConsumerConfiguration(jwsConfiguration))
+
+    /**
+     * The simple producer.
+     */
+    lazy val producer = new SimpleProducer(jwsConfiguration)
+
+    /**
+     * The simple consumer.
+     */
+    lazy val consumer = new SimpleConsumer(simpleConsumerConfiguration)
+
+    /**
+     * The generator to test.
+     */
+    lazy val generator = new Jose4jJwtGenerator(producer, consumer)
+
+    /**
+     * A helper method which encodes claims into a JWT and then decodes the JWT to check if the same
+     * claims were decoded.
+     *
+     * @param claims The claims to check for.
+     * @return A Specs2 match result.
+     */
+    protected def generate(claims: JwtClaims): MatchResult[Any] = {
+      generator.encode(claims) must beSuccessfulTry.like {
+        case jwt =>
+          generator.decode(jwt) must beSuccessfulTry.withValue(claims)
+      }
+    }
+
+    /**
+     * A helper method which encodes claims into a JWT and then decodes the JWT to check if the consumer
+     * throws an exception which indicates that the token is fraudulent.
+     *
+     * @param claims The claims to check for.
+     * @return A Specs2 match result.
+     */
+    protected def fraudulent(claims: JwtClaims): MatchResult[Any] = {
+      generator.encode(claims) must beSuccessfulTry.like {
+        case jwt =>
+          generator.decode(jwt) must beFailedTry.like {
+            case e: JwtException => e.getMessage must startWith(FraudulentJwtToken.format(""))
+          }
+      }
+    }
+  }
+}

--- a/silhouette-specs2/src/main/scala/silhouette/specs2/WithBouncyCastle.scala
+++ b/silhouette-specs2/src/main/scala/silhouette/specs2/WithBouncyCastle.scala
@@ -15,13 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Dependencies._
+package silhouette.specs2
 
-libraryDependencies ++= Seq(
-  Library.Specs2.core,
-  Library.Specs2.matcherExtra,
-  Library.Specs2.mock,
-  Library.mockito,
-  Library.bouncyCastle
-)
-enablePlugins(Doc)
+import java.security.Security
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.specs2.mutable.Specification
+
+/**
+ * Add the Bouncy Castle JCE provider to a test.
+ */
+trait WithBouncyCastle {
+  self: Specification =>
+
+  try {
+    val provider = new BouncyCastleProvider()
+    if (Option(Security.getProvider(provider.getName)).isDefined) {
+      Security.removeProvider(provider.getName)
+    }
+    Security.addProvider(provider)
+  } catch {
+    case e: Exception => throw new RuntimeException("Could not initialize bouncy castle encryption", e)
+  }
+}

--- a/silhouette-specs2/src/test/scala/silhouette.specs2/WithBouncyCastleSpec.scala
+++ b/silhouette-specs2/src/test/scala/silhouette.specs2/WithBouncyCastleSpec.scala
@@ -17,31 +17,31 @@
  */
 package silhouette.specs2
 
-import org.specs2.concurrent.ExecutionEnv
-import org.specs2.matcher.Matcher
+import java.security.Security
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.specs2.mutable.Specification
 
-import scala.concurrent.Future
-import scala.concurrent.duration._
-import scala.languageFeature.implicitConversions
-
 /**
- * Helper to wait with patience to a result.
- *
- * This is needed to prevent the tests for timeouts.
+ * Test case for the [[WithBouncyCastle]] trait.
  */
-trait WaitPatience {
-  self: Specification =>
+class WithBouncyCastleSpec extends Specification {
 
-  val retries: Int = 10
+  "The trait" should {
+    "add the `BouncyCastleProvider` if it's not registered" in {
+      new Specification with WithBouncyCastle
 
-  val timeout: FiniteDuration = 1.second
+      val provider = new BouncyCastleProvider()
+      Option(Security.getProvider(provider.getName)) must beSome
+    }
 
-  implicit class WaitWithPatienceFutureMatchable[T](m: Matcher[T])(implicit ee: ExecutionEnv)
-    extends FutureMatchable[T](m)(ee) {
+    "add the `BouncyCastleProvider` if it's already registered" in {
+      val provider = new BouncyCastleProvider()
+      Security.addProvider(provider)
 
-    def awaitWithPatience: Matcher[Future[T]] = {
-      await(retries, timeout)
+      new Specification with WithBouncyCastle
+
+      Option(Security.getProvider(provider.getName)) must beSome
     }
   }
 }

--- a/silhouette/build.sbt
+++ b/silhouette/build.sbt
@@ -18,6 +18,7 @@
 import Dependencies._
 
 libraryDependencies ++= Seq(
+  Library.jsonAst,
   Library.slf4jApi,
   Library.inject,
   Library.commonCodec

--- a/silhouette/src/main/scala/silhouette/crypto/Hash.scala
+++ b/silhouette/src/main/scala/silhouette/crypto/Hash.scala
@@ -19,44 +19,68 @@ package silhouette.crypto
 
 import java.security.MessageDigest
 
+import scala.io.Codec
+import scala.language.implicitConversions
+
 /**
  * Hash helper.
  */
 object Hash {
 
   /**
-   * Creates a SHA1 hash from the given string.
-   *
-   * @param str The string to create a hash from.
-   * @return The SHA1 hash of the string.
+   * The default codec used to convert the string into a byte array.
    */
-  def sha1(str: String): String = sha1(str.getBytes("UTF-8"))
+  implicit val codec: Codec = Codec.UTF8
 
   /**
-   * Creates a SHA1 hash from the given byte array.
+   * An implicit converter which converts a string into a byte array.
+   *
+   * @param str   The string to convert.
+   * @param codec The codec used to convert the string into a byte array.
+   * @return The byte array representation of the string.
+   */
+  implicit def strToByteArray(str: String)(implicit codec: Codec): Array[Byte] = str.getBytes(codec.charSet)
+
+  /**
+   * Creates a SHA-1 hash from the given byte array.
    *
    * @param bytes The bytes to create a hash from.
-   * @return The SHA1 hash of the bytes.
+   * @return The SHA-1 hash of the bytes.
    */
-  def sha1(bytes: Array[Byte]): String = {
-    MessageDigest.getInstance("SHA-1").digest(bytes).map("%02x".format(_)).mkString
-  }
+  def sha1(bytes: Array[Byte]): String = hash("SHA-1", bytes)
 
   /**
-   * Creates a SHA2 hash from the given string.
-   *
-   * @param str The string to create a hash from.
-   * @return The SHA2 hash of the string.
-   */
-  def sha2(str: String): String = sha2(str.getBytes("UTF-8"))
-
-  /**
-   * Creates a SHA2 hash from the given byte array.
+   * Creates a SHA-256 hash from the given byte array.
    *
    * @param bytes The bytes to create a hash from.
-   * @return The SHA2 hash of the bytes.
+   * @return The SHA-256 hash of the bytes.
    */
-  def sha2(bytes: Array[Byte]): String = {
-    MessageDigest.getInstance("SHA-256").digest(bytes).map("%02x".format(_)).mkString
+  def sha256(bytes: Array[Byte]): String = hash("SHA-256", bytes)
+
+  /**
+   * Creates a SHA-384 hash from the given byte array.
+   *
+   * @param bytes The bytes to create a hash from.
+   * @return The SHA-384 hash of the bytes.
+   */
+  def sha384(bytes: Array[Byte]): String = hash("SHA-384", bytes)
+
+  /**
+   * Creates a SHA-512 hash from the given byte array.
+   *
+   * @param bytes The bytes to create a hash from.
+   * @return The SHA-512 hash of the bytes.
+   */
+  def sha512(bytes: Array[Byte]): String = hash("SHA-512", bytes)
+
+  /**
+   * Gets the hash for the given algorithm and the given bytes.
+   *
+   * @param algorithm The hash algorithm to use.
+   * @param bytes     The bytes to create a hash from.
+   * @return The hash for the given algorithm and the given bytes.
+   */
+  private def hash(algorithm: String, bytes: Array[Byte]): String = {
+    MessageDigest.getInstance(algorithm).digest(bytes).map("%02x".format(_)).mkString
   }
 }

--- a/silhouette/src/main/scala/silhouette/exceptions/JwtException.scala
+++ b/silhouette/src/main/scala/silhouette/exceptions/JwtException.scala
@@ -15,13 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Dependencies._
+package silhouette.exceptions
 
-libraryDependencies ++= Seq(
-  Library.Specs2.core,
-  Library.Specs2.matcherExtra,
-  Library.Specs2.mock,
-  Library.mockito,
-  Library.bouncyCastle
-)
-enablePlugins(Doc)
+/**
+ * Indicates that a JWT encoding/decoding issue occurred.
+ *
+ * @param msg   The exception message.
+ * @param cause The exception cause.
+ */
+class JwtException(msg: String, cause: Option[Throwable] = None)
+  extends SilhouetteException(msg, cause)

--- a/silhouette/src/main/scala/silhouette/jwt/JwaAlgorithm.scala
+++ b/silhouette/src/main/scala/silhouette/jwt/JwaAlgorithm.scala
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Minutemen Group under one or more contributor license
+ * agreements. See the COPYRIGHT file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package silhouette.jwt
+
+import java.security.interfaces.{ ECPrivateKey, ECPublicKey, RSAPrivateKey, RSAPublicKey }
+import javax.crypto.SecretKey
+
+/**
+ * Base trait for a JWA(JSON Web Algorithms) algorithm.
+ *
+ * A JWA algorithm can be used with the JSON Web Signature ([JWS](https://tools.ietf.org/html/rfc7515)),
+ * JSON Web Encryption ([JWE](https://tools.ietf.org/html/rfc7516)), and JSON Web Key
+ * ([JWK](https://tools.ietf.org/html/rfc7517)) specifications.
+ *
+ * The JWS-NONE algorithm isn't supported by Silhouette because it doesn't provide any security.
+ *
+ * @see https://tools.ietf.org/html/rfc7518
+ * @tparam T The type of the algorithm representation.
+ */
+sealed trait JwaAlgorithm[T] {
+
+  /**
+   * Gets the algorithm in the specified representation.
+   *
+   * @return The algorithm in the specified representation.
+   */
+  def get: T
+}
+
+/**
+ * A JWS algorithm which uses asymmetric cryptography like RSA or EC.
+ *
+ * @tparam T The type of the algorithm representation.
+ */
+sealed trait JwsAsymmetricAlgorithm[T] extends JwaAlgorithm[T]
+
+/**
+ * A JWS algorithm which is based on a HMAC(Keyed-Hash Message Authentication Code).
+ *
+ * @see https://tools.ietf.org/html/rfc7518#section-3.2
+ * @tparam T The type of the algorithm representation.
+ */
+trait JwsHmacAlgorithm[T] extends JwaAlgorithm[T]
+
+/**
+ * A JWS algorithm which is based on asymmetric RSA cryptography.
+ *
+ * @see https://tools.ietf.org/html/rfc7518#section-3.3
+ * @tparam T The type of the algorithm representation.
+ */
+trait JwsRsaAlgorithm[T] extends JwsAsymmetricAlgorithm[T]
+
+/**
+ * A JWS algorithm which is based on asymmetric EC(elliptic-curve) cryptography.
+ *
+ * @see https://tools.ietf.org/html/rfc7518#section-3.4
+ * @tparam T The type of the algorithm representation.
+ */
+trait JwsEcAlgorithm[T] extends JwsAsymmetricAlgorithm[T]
+
+/**
+ * A JWS algorithm which is based on asymmetric RSA cryptography and the Probabilistic Signature Scheme.
+ *
+ * @see https://tools.ietf.org/html/rfc7518#section-3.5
+ * @tparam T The type of the algorithm representation.
+ */
+trait JwsRsaPssAlgorithm[T] extends JwsAsymmetricAlgorithm[T]
+
+/**
+ * Base trait for a JWS configuration.
+ *
+ * @tparam T The type of the algorithm representation.
+ */
+sealed trait JwsConfiguration[T] {
+
+  /**
+   * Gets the JWA algorithm used with the JWS configuration.
+   *
+   * @return The JWA algorithm used with the JWS configuration.
+   */
+  def algorithm: JwaAlgorithm[T]
+}
+
+/**
+ * The JWS configuration for HMAC based algorithms.
+ *
+ * @param algorithm Any of the available HMAC based algorithms.
+ * @param key       The secret key.
+ * @tparam T The type of the algorithm representation.
+ */
+case class JwsHmacConfiguration[T](algorithm: JwsHmacAlgorithm[T], key: SecretKey)
+  extends JwsConfiguration[T]
+
+/**
+ * The JWS configuration for asymmetric RSA cryptography based algorithms.
+ *
+ * @param algorithm  Any of the available RSA based algorithms.
+ * @param publicKey  The public key.
+ * @param privateKey The private key.
+ * @tparam T The type of the algorithm representation.
+ */
+case class JwsRsaConfiguration[T](algorithm: JwsRsaAlgorithm[T], publicKey: RSAPublicKey, privateKey: RSAPrivateKey)
+  extends JwsConfiguration[T]
+
+/**
+ * The JWS configuration for asymmetric EC(elliptic-curve) cryptography based algorithms.
+ *
+ * @param algorithm  Any of the available EC based algorithms.
+ * @param publicKey  The public key.
+ * @param privateKey The private key.
+ * @tparam T The type of the algorithm representation.
+ */
+case class JwsEcConfiguration[T](algorithm: JwsEcAlgorithm[T], publicKey: ECPublicKey, privateKey: ECPrivateKey)
+  extends JwsConfiguration[T]
+
+/**
+ * The JWS configuration for asymmetric RSA-PSS cryptography based algorithms.
+ *
+ * @param algorithm  Any of the available RSA-PSS based algorithms.
+ * @param publicKey  The public key.
+ * @param privateKey The private key.
+ * @tparam T The type of the algorithm representation.
+ */
+case class JwsRsaPssConfiguration[T](
+  algorithm: JwsRsaPssAlgorithm[T],
+  publicKey: RSAPublicKey,
+  privateKey: RSAPrivateKey)
+  extends JwsConfiguration[T]

--- a/silhouette/src/main/scala/silhouette/jwt/JwtGenerator.scala
+++ b/silhouette/src/main/scala/silhouette/jwt/JwtGenerator.scala
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Minutemen Group under one or more contributor license
+ * agreements. See the COPYRIGHT file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package silhouette.jwt
+
+import scala.json.ast.JObject
+import scala.util.Try
+
+/**
+ * JWT reserved claims and also optional custom claims in the form of a JSON string.
+ *
+ * See the [JWT RFC](https://tools.ietf.org/html/rfc7519#section-4) for
+ * the full description of the claims.
+ *
+ * @param issuer         The JWT 'iss' claim.
+ * @param subject        The JWT 'sub' claim.
+ * @param audience       The JWT 'aud' claim.
+ * @param expirationTime The JWT 'exp' claim in seconds.
+ * @param notBefore      The JWT 'nbf' claim in seconds.
+ * @param issuedAt       The JWT 'iat' claim in seconds.
+ * @param jwtID          The JWT 'jti' claim.
+ * @param custom         Some custom claims as JSON.
+ */
+case class JwtClaims(
+  issuer: Option[String] = None,
+  subject: Option[String] = None,
+  audience: Option[List[String]] = None,
+  expirationTime: Option[Long] = None,
+  notBefore: Option[Long] = None,
+  issuedAt: Option[Long] = None,
+  jwtID: Option[String] = None,
+  custom: JObject = JObject())
+
+/**
+ * Specifies encoding of JWTs.
+ */
+trait JwtEncoder {
+
+  /**
+   * Encodes a JWT claims object and returns a JWT as string.
+   *
+   * @param jwt The JWT claims object to encode.
+   * @return The JWT string representation or an error if the JWT claims object couldn't be encoded.
+   */
+  def encode(jwt: JwtClaims): Try[String]
+}
+
+/**
+ * Specifies decoding of JWTs.
+ */
+trait JwtDecoder {
+
+  /**
+   * Decodes a JWT string and returns a JWT claims object.
+   *
+   * @param str A JWT string.
+   * @return The decoded JWT claims object or an error if the string couldn't be decoded.
+   */
+  def decode(str: String): Try[JwtClaims]
+}
+
+/**
+ * JWT encoder/decoder.
+ */
+trait JwtGenerator extends JwtEncoder with JwtDecoder

--- a/silhouette/src/test/scala/silhouette/crypto/HashSpec.scala
+++ b/silhouette/src/test/scala/silhouette/crypto/HashSpec.scala
@@ -18,6 +18,7 @@
 package silhouette.crypto
 
 import org.specs2.mutable.Specification
+import silhouette.crypto.Hash._
 
 /**
  * Test case for the [[Hash]] object.
@@ -25,15 +26,30 @@ import org.specs2.mutable.Specification
 class HashSpec extends Specification {
 
   "The `sha1` method" should {
-    "create a SHA1 hash of a string" in {
-      Hash.sha1("SÄÜ%&/($§QW@\\'Ä_:;>|§`´*~") must be equalTo "a87babacb5ef14f1f811527c2028706a55c56be5"
+    "create a SHA-1 hash of a string with UTF-8 decoding" in {
+      sha1("SÄÜ%&/($§QW@\\'Ä_:;>|§`´*~") must be equalTo "a87babacb5ef14f1f811527c2028706a55c56be5"
     }
   }
 
-  "The `sha2` method" should {
-    "create a SHA2 hash of a string" in {
-      Hash.sha2("SÄÜ%&/($§QW@\\'Ä_:;>|§`´*~") must be equalTo
+  "The `sha256` method" should {
+    "create a SHA-256 hash of a string" in {
+      sha256("SÄÜ%&/($§QW@\\'Ä_:;>|§`´*~") must be equalTo
         "162b62e492f8f4d979d5f96c1fb96c7bf5c0621f48f0613bf16fa527e41c54e5"
+    }
+  }
+
+  "The `sha384` method" should {
+    "create a SHA-384 hash of a string" in {
+      sha384("SÄÜ%&/($§QW@\\'Ä_:;>|§`´*~") must be equalTo
+        "d0f9cc557e46731b3473548d4ccb228ca73d327c8b460e48bf0c465563cde632a7e07774ddce0998e488e38e4ea6aec7"
+    }
+  }
+
+  "The `sha512` method" should {
+    "create a SHA-512 hash of a string" in {
+      sha512("SÄÜ%&/($§QW@\\'Ä_:;>|§`´*~") must be equalTo
+        "dfa7f66ff599f21a91c8aedb6bfafb12b029e3f4856866d3f7a51d5701e06d101e4a5dd55d9009e96fbfad3f1ec972dd7634431" +
+        "5ca311766f4d50b94a0f32edb"
     }
   }
 }


### PR DESCRIPTION
This is a first implementation of the JWT generator. The core defines a generator interface with an encoder and decoder as also a claims object which holds the data of the JWT and which can be used in the authenticator. For customs claims I use the [Scala JSON AST](https://contributors.scala-lang.org/t/scala-json-ast-sp-proposal/175/6) which gets hopefully accepted in the near future. So a user could use any JSON library that implements the AST. In the meantime the user must construct the JSON with the AST.

As concrete implementation I use [jose4j](https://bitbucket.org/b_c/jose4j/wiki/Home) which seems the best JWT library around. As noted in the comments of the `Jose4jJwtConsumer` and the `Jose4jJwtProducer` it can be really complex to encode and decode a JSON these days. We have JWT, JWS, JWE and JWK standards. So I would let the user implement the encoding and decoding with the help of the `Jose4jJwtConsumer` and the `Jose4jJwtProducer`. Maybe we could implement a simple JWS implementation with common signature algorithms.

Tests are currently missing!