### PR TITLE
Use the new encoder and decoder traits and polish some doc comments

### DIFF
--- a/silhouette-jwt-jose4j/src/main/scala/silhouette/jwt/Jose4jJwtGenerator.scala
+++ b/silhouette-jwt-jose4j/src/main/scala/silhouette/jwt/Jose4jJwtGenerator.scala
@@ -17,9 +17,7 @@
  */
 package silhouette.jwt
 
-import org.jose4j.jwt.consumer.JwtConsumerBuilder
 import org.jose4j.jwt.{ NumericDate, JwtClaims => JJwtClaims }
-import org.jose4j.jwx.JsonWebStructure
 import silhouette.exceptions.JwtException
 import silhouette.jwt.Jose4jJwtGenerator._
 

--- a/silhouette/src/main/scala/silhouette/http/client/Body.scala
+++ b/silhouette/src/main/scala/silhouette/http/client/Body.scala
@@ -17,16 +17,17 @@
  */
 package silhouette.http.client
 
-import java.nio.charset.{ Charset, StandardCharsets }
+import scala.io.Codec
 
 /**
- * Represents a body of a Request.
+ * Represents the body of a request.
  *
- * @param contentType The content type of body.
- * @param data The data of body.
+ * @param contentType The content type of the body.
+ * @param codec       The codec of the body.
+ * @param data        The body data.
  */
 final case class Body(
   contentType: ContentType,
-  charset: Charset = StandardCharsets.UTF_8,
+  codec: Codec = Codec.UTF8,
   data: Array[Byte]
 )

--- a/silhouette/src/main/scala/silhouette/http/client/ContentTypes.scala
+++ b/silhouette/src/main/scala/silhouette/http/client/ContentTypes.scala
@@ -20,12 +20,12 @@ package silhouette.http.client
 /**
  * Represents the content type of a request.
  *
- * @param value String format for content-type.
+ * @param value String format for a content type.
  */
 final case class ContentType(value: String)
 
 /**
- * Util class for content-type values.
+ * Util class for content type values.
  */
 object ContentTypes {
   val `application/json` = ContentType("application/json")

--- a/silhouette/src/main/scala/silhouette/http/client/decoder/BodyDecoder.scala
+++ b/silhouette/src/main/scala/silhouette/http/client/decoder/BodyDecoder.scala
@@ -15,28 +15,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package silhouette.http
+package silhouette.http.client.decoder
 
 import silhouette.http.client.Body
+import silhouette.util.Decoder
+
 import scala.util.Try
 
 /**
- * This package contains decode feature.
+ * Represents a decode action that extract from [[Body]] to an instance of T.
+ *
+ * @tparam T The target type.
  */
-package object decoder {
+trait BodyDecoder[T] extends Decoder[Body, Try[T]]
 
-  /**
-   * Provides syntax via enrichment classes.
-   */
-  implicit final class DecoderOps[A <: Body](val wrapped: A) {
-
-    /**
-     * Provide method that decode from Body to a T.
-     *
-     * @param decoder Decoder instance able to decode.
-     * @tparam T The result type to decode.
-     * @return an instance of T or an error if the body couldn't be decoded.
-     */
-    def as[T](implicit decoder: BodyDecoder[T]): Try[T] = decoder.decode(wrapped)
-  }
-}
+/**
+ * The only aim of this object is to provide a default implicit [[BodyDecoder]], that uses
+ * the [[DefaultBodyDecoder]] trait to provide the lowest implicit conversion chain.
+ */
+object BodyDecoder extends DefaultBodyDecoder

--- a/silhouette/src/main/scala/silhouette/http/client/decoder/package.scala
+++ b/silhouette/src/main/scala/silhouette/http/client/decoder/package.scala
@@ -15,21 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package silhouette.http.decoder
+package silhouette.http.client
 
-import silhouette.http.client.Body
-import silhouette.util.Decoder
 import scala.util.Try
 
 /**
- * Represents a decode action that extract from [[silhouette.http.client.Body]] an instance of B.
- *
- * @tparam T The type target of decode action.
+ * Provides HTTP decoder implementations.
  */
-trait BodyDecoder[T] extends Decoder[Body, Try[T]]
+package object decoder {
 
-/**
- * The only aim of this object is to provide default implicit BodyDecoder,
- * uses trait for provide lowest implicit conversion chain.
- */
-object BodyDecoder extends DefaultBodyDecoder
+  /**
+   * Provides syntax via enrichment classes.
+   *
+   * @param body The [[Body]] instance on which the additional methods should be defined.
+   */
+  implicit final class RichBody[A <: Body](body: A) {
+
+    /**
+     * Provides a method that decodes from [[Body]] to T.
+     *
+     * @param decoder An implicit [[BodyDecoder]] instance that is used to decode the body.
+     * @tparam T The type of the result.
+     * @return An instance of T or an error if the body couldn't be decoded.
+     */
+    def as[T](implicit decoder: BodyDecoder[T]): Try[T] = decoder.decode(body)
+  }
+}

--- a/silhouette/src/main/scala/silhouette/http/transport/package.scala
+++ b/silhouette/src/main/scala/silhouette/http/transport/package.scala
@@ -18,6 +18,6 @@
 package silhouette.http
 
 /**
- * HTTP transport implementations.
+ * Provides HTTP transport implementations.
  */
 package object transport {}

--- a/silhouette/src/main/scala/silhouette/jwt/JwtGenerator.scala
+++ b/silhouette/src/main/scala/silhouette/jwt/JwtGenerator.scala
@@ -17,11 +17,13 @@
  */
 package silhouette.jwt
 
+import silhouette.util.{ Decoder, Encoder }
+
 import scala.json.ast.JObject
 import scala.util.Try
 
 /**
- * JWT reserved claims and also optional custom claims in the form of a JSON string.
+ * JWT reserved claims and also optional custom claims in the form of a JSON object.
  *
  * See the [JWT RFC](https://tools.ietf.org/html/rfc7519#section-4) for
  * the full description of the claims.
@@ -46,34 +48,6 @@ case class JwtClaims(
   custom: JObject = JObject())
 
 /**
- * Specifies encoding of JWTs.
- */
-trait JwtEncoder {
-
-  /**
-   * Encodes a JWT claims object and returns a JWT as string.
-   *
-   * @param jwt The JWT claims object to encode.
-   * @return The JWT string representation or an error if the JWT claims object couldn't be encoded.
-   */
-  def encode(jwt: JwtClaims): Try[String]
-}
-
-/**
- * Specifies decoding of JWTs.
- */
-trait JwtDecoder {
-
-  /**
-   * Decodes a JWT string and returns a JWT claims object.
-   *
-   * @param str A JWT string.
-   * @return The decoded JWT claims object or an error if the string couldn't be decoded.
-   */
-  def decode(str: String): Try[JwtClaims]
-}
-
-/**
  * JWT encoder/decoder.
  */
-trait JwtGenerator extends JwtEncoder with JwtDecoder
+trait JwtGenerator extends Encoder[JwtClaims, Try[String]] with Decoder[String, Try[JwtClaims]]

--- a/silhouette/src/main/scala/silhouette/util/Decoder.scala
+++ b/silhouette/src/main/scala/silhouette/util/Decoder.scala
@@ -18,17 +18,17 @@
 package silhouette.util
 
 /**
- * Represents a decode action that extract from A an instance of B.
+ * Represents a decode action that transform an instance of A to B.
  *
- * @tparam A The raw data source of decode action.
- * @tparam B The type target of decode action.
+ * @tparam A The source type.
+ * @tparam B The target type.
  */
 trait Decoder[A, B] {
 
   /**
-   * Decode from A to target B.
+   * Decode from source A to target B.
    *
-   * @param in The raw data source of decode action.
+   * @param in The source to decode.
    * @return An instance of B.
    */
   def decode(in: A): B

--- a/silhouette/src/main/scala/silhouette/util/Encoder.scala
+++ b/silhouette/src/main/scala/silhouette/util/Encoder.scala
@@ -20,15 +20,15 @@ package silhouette.util
 /**
  * Represents an encode action that transform an instance of A to B.
  *
- * @tparam A The data source of encode action.
- * @tparam B The type target of encode action.
+ * @tparam A The source type.
+ * @tparam B The target type.
  */
 trait Encoder[A, B] {
 
   /**
-   * Encode from A to target B.
+   * Encode from source A to target B.
    *
-   * @param in The data source of encode action.
+   * @param in The source to encode.
    * @return An instance of B.
    */
   def encode(in: A): B

--- a/silhouette/src/test/scala/silhouette/http/client/decoder/DefaultBodyDecoderSpec.scala
+++ b/silhouette/src/test/scala/silhouette/http/client/decoder/DefaultBodyDecoderSpec.scala
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package silhouette.http.decoder
+package silhouette.http.client.decoder
 
 import java.nio.charset.StandardCharsets
 


### PR DESCRIPTION
* Use the encoder and decoder trait for the JWT generator trait
* Polished some doc comments
* Use the Scala codec implementation instead of the java charset implementation
* Move http decoder implementations into the `silhouette.http.client` package
