### PR TITLE
Remove Scala JSON AST and use circe instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: scala
 scala:
-- 2.12.7
+- 2.12.8
 jdk:
 - oraclejdk8
 env:

--- a/modules/authenticator/build.sbt
+++ b/modules/authenticator/build.sbt
@@ -18,7 +18,6 @@
 import Dependencies._
 
 libraryDependencies ++= Seq(
-  Library.jsonAst,
   Library.Circe.core,
 )
 //enablePlugins(Doc)

--- a/modules/authenticator/src/main/scala/silhouette/authenticator/Authenticator.scala
+++ b/modules/authenticator/src/main/scala/silhouette/authenticator/Authenticator.scala
@@ -19,13 +19,13 @@ package silhouette.authenticator
 
 import java.time.{ Clock, Instant }
 
+import io.circe.Json
 import silhouette.LoginInfo
 import silhouette.authenticator.Authenticator.Implicits._
 import silhouette.http.RequestPipeline
 
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.json.ast.JObject
 
 /**
  * An authenticator tracks an authenticated user.
@@ -56,7 +56,7 @@ final case class Authenticator(
   expires: Option[Instant] = None,
   fingerprint: Option[String] = None,
   tags: Seq[String] = Seq(),
-  payload: Option[JObject] = None) {
+  payload: Option[Json] = None) {
 
   /**
    * Gets the duration the authenticator expires in.

--- a/modules/authenticator/src/test/scala/silhouette/authenticator/format/JwtWritesSpec.scala
+++ b/modules/authenticator/src/test/scala/silhouette/authenticator/format/JwtWritesSpec.scala
@@ -19,18 +19,18 @@ package silhouette.authenticator.format
 
 import java.time.Instant
 
+import io.circe.{ Json, JsonObject }
 import io.circe.syntax._
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.Scope
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
+import silhouette.LoginInfo
 import silhouette.authenticator.{ Authenticator, StatefulWrites, StatelessWrites }
 import silhouette.crypto.Base64
 import silhouette.jwt.{ Claims, Writes }
 import silhouette.specs2.WaitPatience
-import silhouette.LoginInfo
 
-import scala.json.ast._
 import scala.util.Try
 
 /**
@@ -96,13 +96,11 @@ class JwtWritesSpec(implicit ev: ExecutionEnv) extends Specification with Mockit
       notBefore = Some(instant),
       issuedAt = Some(instant),
       jwtID = Some("id"),
-      custom = JObject(Map(
-        "tags" -> JArray(JString("tag1"), JString("tag2")),
-        "fingerprint" -> JString("fingerprint"),
-        "payload" -> JObject(Map(
-          "secure" -> JTrue
-        ))
-      ))
+      custom = JsonObject(
+        "tags" -> Json.arr(Json.fromString("tag1"), Json.fromString("tag2")),
+        "fingerprint" -> Json.fromString("fingerprint"),
+        "payload" -> Json.obj("secure" -> Json.True)
+      )
     )
 
     /**
@@ -115,9 +113,7 @@ class JwtWritesSpec(implicit ev: ExecutionEnv) extends Specification with Mockit
       expires = Some(instant),
       fingerprint = Some("fingerprint"),
       tags = Seq("tag1", "tag2"),
-      payload = Some(JObject(Map(
-        "secure" -> JTrue
-      )))
+      payload = Some(Json.obj("secure" -> Json.True))
     )
 
     /**

--- a/modules/jwt/build.sbt
+++ b/modules/jwt/build.sbt
@@ -18,6 +18,6 @@
 import Dependencies._
 
 libraryDependencies ++= Seq(
-  Library.jsonAst
+  Library.Circe.core
 )
 //enablePlugins(Doc)

--- a/modules/jwt/src/main/scala/silhouette/jwt/Claims.scala
+++ b/modules/jwt/src/main/scala/silhouette/jwt/Claims.scala
@@ -19,7 +19,7 @@ package silhouette.jwt
 
 import java.time.Instant
 
-import scala.json.ast.JObject
+import io.circe.JsonObject
 
 /**
  * JWT reserved claims and also optional custom claims in the form of a JSON object.
@@ -44,5 +44,5 @@ final case class Claims(
   notBefore: Option[Instant] = None,
   issuedAt: Option[Instant] = None,
   jwtID: Option[String] = None,
-  custom: JObject = JObject()
+  custom: JsonObject = JsonObject.empty
 )

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -28,7 +28,7 @@ object BasicSettings extends AutoPlugin {
     organization := "group.minutemen",
     resolvers ++= Dependencies.resolvers,
     scalaVersion := crossScalaVersions.value.head,
-    crossScalaVersions := Seq("2.12.7"),
+    crossScalaVersions := Seq("2.12.8"),
     scalacOptions ++= Seq(
       "-deprecation", // Emit warning and location for usages of deprecated APIs.
       "-feature", // Emit warning and location for usages of features that should be imported explicitly.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
 
   object Version {
     val specs2 = "4.3.3"
-    val circe = "0.7.0"
+    val circe = "0.10.1"
   }
 
   val resolvers = Seq()
@@ -37,7 +37,7 @@ object Dependencies {
     object Circe {
       val core = "io.circe" %% "circe-core" % Version.circe
       val parser = "io.circe" %% "circe-parser" % Version.circe
-      val optics = "io.circe" %% "circe-optics" % Version.circe
+      val optics = "io.circe" %% "circe-optics" % "0.10.0"
     }
 
     val mockito = "org.mockito" % "mockito-core" % "1.10.19"
@@ -46,7 +46,6 @@ object Dependencies {
     val inject = "javax.inject" % "javax.inject" % "1"
     val commonCodec = "commons-codec" % "commons-codec" % "1.10"
     val jose4j = "org.bitbucket.b_c" % "jose4j" % "0.5.4"
-    val jsonAst = "org.mdedetrich" %% "scala-json-ast" % "1.0.0-M7"
     val bouncyCastle = "org.bouncycastle" % "bcprov-jdk15on" % "1.56"
     val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.0.6"
     val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2"


### PR DESCRIPTION
The scala-json-ast project isn't widely adopted in the Scala community. So we drop it and use Circe instead, because the rest of the project uses it already.